### PR TITLE
Force processes order

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -4,7 +4,7 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
   load_and_authorize_resource :process, class: "Legislation::Process"
 
   def index
-    @processes = ::Legislation::Process.send(@current_filter).page(params[:page])
+    @processes = ::Legislation::Process.send(@current_filter).order('id DESC').page(params[:page])
   end
 
   def create

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -19,9 +19,9 @@ class Legislation::Process < ActiveRecord::Base
   validates :allegations_end_date, presence: true
   validates :final_publication_date, presence: true
 
-  scope :open, -> {where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
-  scope :next, -> {where("start_date > ?", Date.current) }
-  scope :past, -> {where("end_date < ?", Date.current) }
+  scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current).order('id DESC') }
+  scope :next, -> { where("start_date > ?", Date.current).order('id DESC') }
+  scope :past, -> { where("end_date < ?", Date.current).order('id DESC') }
 
   def open_phase?(phase)
     today = Date.current


### PR DESCRIPTION
Implements #41 

Order is by "id DESC" because created_at doesn't have an index in the db, but it could be changed to use that instead and add the missing indexes.