### PR TITLE
Validate date ranges for legislation process

### DIFF
--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -18,6 +18,7 @@ class Legislation::Process < ActiveRecord::Base
   validates :allegations_start_date, presence: true
   validates :allegations_end_date, presence: true
   validates :final_publication_date, presence: true
+  validate :valid_date_ranges
 
   scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current).order('id DESC') }
   scope :next, -> { where("start_date > ?", Date.current).order('id DESC') }
@@ -57,4 +58,13 @@ class Legislation::Process < ActiveRecord::Base
   def total_comments
     questions.map(&:comments_count).sum
   end
+
+  private
+
+    def valid_date_ranges
+      errors.add(:end_date, :invalid_date_range) if end_date < start_date
+      errors.add(:debate_end_date, :invalid_date_range) if debate_end_date < debate_start_date
+      errors.add(:allegations_end_date, :invalid_date_range) if allegations_end_date < allegations_start_date
+    end
+
 end

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -127,6 +127,14 @@ en:
           attributes:
             max_per_day:
               invalid: "You have reached the maximum number of private messages per day"
+        legislation/process:
+          attributes:
+            end_date:
+              invalid_date_range: must be on or after the start date
+            debate_end_date:
+              invalid_date_range: must be on or after the debate start date
+            allegations_end_date:
+              invalid_date_range: must be on or after the allegations start date
         proposal:
           attributes:
             tag_list:

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -127,6 +127,14 @@ es:
           attributes:
             max_per_day:
               invalid: "Has llegado al número máximo de mensajes privados por día"
+        legislation/process:
+          attributes:
+            end_date:
+              invalid_date_range: tiene que ser igual o posterior a la fecha de inicio
+            debate_end_date:
+              invalid_date_range: tiene que ser igual o posterior a la fecha de inicio del debate
+            allegations_end_date:
+              invalid_date_range: tiene que ser igual o posterior a la fecha de inicio de las alegaciones
         proposal:
           attributes:
             tag_list:

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -7,6 +7,41 @@ RSpec.describe Legislation::Process, type: :model do
     expect(legislation_process).to be_valid
   end
 
+  describe "date ranges validations" do
+    it "is invalid if end_date is before start_date" do
+      process = build(:legislation_process, start_date: Date.current, end_date: Date.current - 1.day)
+      expect(process).to be_invalid
+      expect(process.errors.messages[:end_date]).to include("must be on or after the start date")
+    end
+
+    it "is valid if end_date is the same as start_date" do
+      process = build(:legislation_process, start_date: Date.current - 1.day, end_date: Date.current - 1.day)
+      expect(process).to be_valid
+    end
+
+    it "is invalid if debate_end_date is before debate start_date" do
+      process = build(:legislation_process, debate_start_date: Date.current, debate_end_date: Date.current - 1.day)
+      expect(process).to be_invalid
+      expect(process.errors.messages[:debate_end_date]).to include("must be on or after the debate start date")
+    end
+
+    it "is valid if debate_end_date is the same as debate_start_date" do
+      process = build(:legislation_process, debate_start_date: Date.current - 1.day, debate_end_date: Date.current - 1.day)
+      expect(process).to be_valid
+    end
+
+    it "is invalid if allegations_end_date is before allegations_start_date" do
+      process = build(:legislation_process, allegations_start_date: Date.current, allegations_end_date: Date.current - 1.day)
+      expect(process).to be_invalid
+      expect(process.errors.messages[:allegations_end_date]).to include("must be on or after the allegations start date")
+    end
+
+    it "is valid if allegations_end_date is the same as allegations_start_date" do
+      process = build(:legislation_process, allegations_start_date: Date.current - 1.day, allegations_end_date: Date.current - 1.day)
+      expect(process).to be_valid
+    end
+  end
+
   describe "filter scopes" do
     before(:each) do
       @process_1 = create(:legislation_process, start_date: Date.current - 2.days, end_date: Date.current + 1.day)


### PR DESCRIPTION
Implements #46 

Only validates start and end dates for the whole process or a phase, not overlap between phases.