### PR TITLE
Refactor header toggle and show additional info on the small header

### DIFF
--- a/app/assets/javascripts/legislation.js.coffee
+++ b/app/assets/javascripts/legislation.js.coffee
@@ -3,11 +3,11 @@ App.Legislation =
   initialize: ->
     $('#js-toggle-debate').on
       click: ->
-        $('#debate-info').toggle()
+        $('#debate-show').toggle()
         
     $('#js-toggle-small-debate').on
       click: ->
-        $('#debate-info').toggle()
+        $('#debate-show').toggle()
         $('span').toggleClass('icon-angle-up')
 
     $('form#new_legislation_answer input.button').hide()

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -62,9 +62,12 @@ $epigraph-font-size: rem-calc(15);
       color: #8AA8BE;
     }
   }
-
-  #debate-info {
+  
+  #debate-show {
     display: none;
+  }
+
+  .debate-add-info {
     margin-top: 3rem;
     padding-top: 4rem;
     border-top: 1px solid darken($border, 10%);
@@ -437,6 +440,10 @@ $epigraph-font-size: rem-calc(15);
 // -----------------
 .legislation-allegation {
   padding-top: 1rem;
+  
+  #debate-show {
+    margin-top: 2rem;
+  }
 
   .headline {
     margin-bottom: 0;

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -12,8 +12,20 @@
       </div>
     </div>
     
-    <div class="row description">
-      <div id="debate-info" style="display: none" class="small-12 column">
+    <div id="debate-show" class="row description">
+      <div class="small-12 medium-4 column">
+        <h4><%= t('legislation.processes.header_full.description') %></h4>
+        <%= markdown process.description %>
+      </div>
+      <div class="small-12 medium-4 column">
+        <h4><%= t('legislation.processes.header_full.target') %></h4>
+        <%= markdown process.target %>
+      </div>
+      <div class="small-12 medium-4 column">
+        <h4><%= t('legislation.processes.header_full.how_to_participate') %></h4>
+        <%= markdown process.how_to_participate %>
+      </div>
+      <div class="small-12 column debate-add-info">
         <div class="debate-info-wrapper">
           <%= markdown process.additional_info if process.additional_info %>
         </div>

--- a/app/views/legislation/processes/_header_full.html.erb
+++ b/app/views/legislation/processes/_header_full.html.erb
@@ -27,7 +27,7 @@
       <h4><%= t('.how_to_participate') %></h4>
       <%= markdown process.how_to_participate %>
     </div>
-    <div id="debate-info" class="small-12 column">
+    <div id="debate-show" class="small-12 column debate-add-info">
       <div class="debate-info-wrapper">
         <%= markdown process.additional_info if process.additional_info %>
       </div>


### PR DESCRIPTION
This PR fixes #80, refactoring the header toggle and adding more info on the small header shown in the draft legislation page.