### PR TITLE
Full width key dates, fix SVG margin

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -187,11 +187,10 @@ $epigraph-font-size: rem-calc(15);
       svg {
         position: absolute;
         top: 1.25rem;
-        left: -1rem;
-
-        @include breakpoint(medium) {
+        
+        @include breakpoint(1280px) {
           transform: rotate(-6deg);
-          top: 0.75rem;
+          left: -1rem;
         }
       }
 

--- a/app/views/legislation/annotations/index.html.erb
+++ b/app/views/legislation/annotations/index.html.erb
@@ -2,9 +2,9 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :small %>
 
-<div class="column row">
-  <%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
+<%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
 
+<div class="column row">
   <div class="draft-panels small-12 column row">
     <%= render 'version_chooser', process: @process, draft_version: @draft_version %>
 

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -2,9 +2,9 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :small %>
 
-<div class="column row">
-  <%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
+<%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
 
+<div class="column row">
   <div class="draft-panels small-12 column row">
     <%= render 'version_chooser', process: @process, draft_version: @draft_version %>
 

--- a/app/views/legislation/draft_versions/changes.html.erb
+++ b/app/views/legislation/draft_versions/changes.html.erb
@@ -2,9 +2,9 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :small %>
 
-<div class="column row">
-  <%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
+<%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
 
+<div class="column row">
   <div class="draft-panels small-12 column row">
     <div class="row draft-chooser">
       <div class="small-12 medium-9 column">

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -2,9 +2,9 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :small %>
 
-<div class="column row">
-  <%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
+<%= render 'legislation/processes/key_dates', process: @process, phase: :allegations %>
 
+<div class="column row">
   <div class="draft-panels small-12 column row">
     <div class="row draft-chooser">
       <div class="small-12 medium-9 column">


### PR DESCRIPTION
This PR fixes #76.

It also moves the key dates html outside of its row in each page, creating a consistent style where the partial is full width for every page and not just in the process index.