### PR TITLE
Unify processes header type

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -132,6 +132,15 @@ $epigraph-line-height: rem-calc(22);
     ul {
       font-size: $epigraph-font-size;
       line-height: $epigraph-line-height;
+      
+      li {
+        margin-bottom: 1rem;
+        
+        p {
+          display: inline;
+          margin-bottom: 0;
+        }
+      }
     }
     
     h4 {

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -35,6 +35,7 @@
 }
 
 $epigraph-font-size: rem-calc(15);
+$epigraph-line-height: rem-calc(22);
 
 // 02. Hero
 // -----------------
@@ -87,7 +88,9 @@ $epigraph-font-size: rem-calc(15);
       }
 
       p {
-        font-size: $base-font-size;
+        font-size: $epigraph-font-size;
+        line-height: $epigraph-line-height;
+        
         @include breakpoint(medium) {
           margin-left: 25%;
         }
@@ -123,14 +126,11 @@ $epigraph-font-size: rem-calc(15);
     
     p {
       font-size: $epigraph-font-size;
+      line-height: $epigraph-line-height;
     }
     
     h4 {
       font-size: $base-font-size;
-    }
-
-    @include breakpoint(medium) {
-        margin-bottom: 0;
     }
   }
 

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -129,6 +129,11 @@ $epigraph-line-height: rem-calc(22);
       line-height: $epigraph-line-height;
     }
     
+    ul {
+      font-size: $epigraph-font-size;
+      line-height: $epigraph-line-height;
+    }
+    
     h4 {
       font-size: $base-font-size;
     }


### PR DESCRIPTION
This fixes #75, applying a consistent font size and line height on the processes header.