### PR TITLE
Ask for confirmation when changing the page and the forms watched do have changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -54,6 +54,7 @@
 //= require legislation
 //= require legislation_allegations
 //= require legislation_annotatable
+//= require watch_form_changes
 //= require custom
 
 var initialize_modules = function() {
@@ -83,6 +84,7 @@ var initialize_modules = function() {
   App.Legislation.initialize();
   if ( $(".legislation-annotatable").length )
     App.LegislationAnnotatable.initialize();
+  App.WatchFormChanges.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/watch_form_changes.js.coffee
+++ b/app/assets/javascripts/watch_form_changes.js.coffee
@@ -1,0 +1,31 @@
+App.WatchFormChanges =
+  forms: ->
+    return $('form[data-watch-changes]')
+
+  msg: ->
+    if($('[data-watch-form-message]').length)
+      return $('[data-watch-form-message]').data('watch-form-message')
+
+  checkChanges: (event) ->
+    console.log(event)
+    changes = false
+    App.WatchFormChanges.forms().each ->
+      form = $(this)
+      if form.serialize() != form.data('watchChanges')
+        changes = true
+    if changes
+      return confirm(App.WatchFormChanges.msg())
+    else
+      return true
+
+  initialize: ->
+    if App.WatchFormChanges.forms().length == 0 || App.WatchFormChanges.msg() == undefined
+      return
+
+    $(document).off('page:before-change').on('page:before-change', (e) -> App.WatchFormChanges.checkChanges(e))
+
+    App.WatchFormChanges.forms().each ->
+      form = $(this)
+      form.data('watchChanges', form.serialize())
+
+    false

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @process, @draft_version], url: url do |f| %>
+<%= form_for [:admin, @process, @draft_version], url: url, html: {data: {watch_changes: true}} do |f| %>
 
   <% if @draft_version.errors.any? %>
 

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @process] do |f| %>
+<%= form_for [:admin, @process], html: {data: {watch_changes: true}} do |f| %>
 
   <% if @process.errors.any? %>
 

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, @process, @question], url: url do |f| %>
+<%= form_for [:admin, @process, @question], url: url, html: {data: {watch_changes: true}} do |f| %>
 
   <% if @question.errors.any? %>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -13,7 +13,7 @@
     <%= favicon_link_tag "favicon.ico" %>
   </head>
 
-  <body class="admin">
+  <body class="admin" data-watch-form-message="<%= I18n.t('layouts.admin.watch_form_message') %>">
     <div class="off-canvas-wrapper">
       <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
         <div class="off-canvas position-left" id="offCanvas" data-off-canvas>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,8 @@ en:
       see_all: See proposals
       budgets: Participatory budgeting
       spending_proposals: Spending Proposals
+    admin:
+      watch_form_message: 'You have unsaved changes. Do you confirm to leave the page?'
   legacy_legislation:
     help:
       alt: Select the text you want to comment and press the button with the pencil.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -218,6 +218,8 @@ es:
       see_all: Ver propuestas
       budgets: Presupuestos ciudadanos
       spending_proposals: "Propuestas de inversión"
+    admin:
+      watch_form_message: 'Has realizado cambios que no han sido guardados. ¿Seguro que quieres abandonar la página?'
   legacy_legislation:
     help:
       alt: Selecciona el texto que quieres comentar y pulsa en el botón con el lápiz.


### PR DESCRIPTION
This PR introduces a nice to have feature for the admins.

When an admin has changed the content of a form, and she tries to leave the page, she'll see a warning message asking for confirmation.

This feature has been integrated only in the legislation forms, but can be enabled in any form by adding `data-watch-changes` attribute to it.

**known limitations**

Because of turbolinks, there are a couple of limitations that aren't very important IMO

- the confirmation message is not triggered if the user instead of clicking a link to leave the page, reloads the page

- once the form has been submitted, the watcher doesn't work