### PR TITLE
Sync scroll in markdown editor

### DIFF
--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -20,6 +20,9 @@ App.MarkdownEditor =
         $('.legislation-draft-versions-edit .warning').show()
         return
 
+      $(this).find('textarea').on 'scroll', ->
+        $('#markdown-preview').scrollTop($(this).scrollTop())
+
       $(this).find('.fullscreen-toggle').on 'click', ->
         $('.markdown-editor').toggleClass('fullscreen')
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -630,7 +630,7 @@ table.investment-projects-summary {
   }
   
   #legislation_draft_version_body {
-    font-family: $font-family-monospace;
+    font-family: $font-family-serif;
     background: #f5f5f5;
     height: 16em;
     
@@ -647,10 +647,14 @@ table.investment-projects-summary {
     
     h1, h2, h3, h4, h5, h6 {
       font-family: $font-family-serif !important;
+      font-size: 1rem;
+      line-height: 1.625rem;
+      margin-bottom: 0;
     }
     
-    h2 {
-      border-bottom: 1px solid $text-medium;
+    p {
+      font-size: 1rem;
+      line-height: 1.625rem;
     }
   }
   


### PR DESCRIPTION
Implements #66 

It doesn't work totally smoothly like this because the length of the lines of texts is different in the preview (a bit longer).