### PR TITLE
Hide legislation text when the full-screen editor is not active

### DIFF
--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -22,9 +22,9 @@ App.MarkdownEditor =
 
       $(this).find('.fullscreen-toggle').on 'click', ->
         $('.markdown-editor').toggleClass('fullscreen')
+        $('.fullscreen-container').toggleClass('medium-8', 'medium-12')
 
         if $('.markdown-editor').hasClass('fullscreen')
           $('.markdown-editor textarea').height($(window).height() - 100)
         else
           $('.markdown-editor textarea').height("10em")
-

--- a/app/assets/javascripts/markdown_editor.js.coffee
+++ b/app/assets/javascripts/markdown_editor.js.coffee
@@ -23,6 +23,12 @@ App.MarkdownEditor =
       $(this).find('.fullscreen-toggle').on 'click', ->
         $('.markdown-editor').toggleClass('fullscreen')
         $('.fullscreen-container').toggleClass('medium-8', 'medium-12')
+        span = $(this).find('span')
+        current_html = span.html()
+        if(current_html == span.data('open-text'))
+          span.html(span.data('closed-text'))
+        else
+          span.html(span.data('open-text'))
 
         if $('.markdown-editor').hasClass('fullscreen')
           $('.markdown-editor textarea').height($(window).height() - 100)

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -411,6 +411,11 @@ table.investment-projects-summary {
 
 .markdown-editor {
   background-color: white;
+  
+  .mardown-area,
+  #markdown-preview {
+    display: none;
+  }
 }
 
 .markdown-editor #markdown-preview {
@@ -437,7 +442,9 @@ table.investment-projects-summary {
 
 // 06. Legislation
 // --------------
-
+.edit_legislation_draft_version .row {
+  margin-bottom: 2rem;
+}
 .legislation-admin {
   .menu .active > a {
     background: none;
@@ -595,6 +602,8 @@ table.investment-projects-summary {
   }
   
   .fullscreen-container {
+    text-align: center;
+    background: #ccdbe6;
     
     .markdown-editor-header,
     .markdown-editor-buttons {
@@ -602,12 +611,7 @@ table.investment-projects-summary {
     }
     
     a {
-
-      @include breakpoint(medium) {
-        float: right;
-      }
-      
-      line-height: 3rem;
+      line-height: 8rem;
       
       span {
         text-decoration: none;
@@ -656,13 +660,28 @@ table.investment-projects-summary {
   
   .fullscreen {
     
+    .mardown-area,
+    #markdown-preview {
+      display: block;
+    }
+    
     .column {
       padding: 0;
     }
     
     .fullscreen-container {
+      text-align: left;
       background: $admin-color;
       padding: 0.5rem 1rem;
+      margin-bottom: 0;
+        
+        a {
+          line-height: 3rem;
+
+          @include breakpoint(medium) {
+            float: right;
+          }
+        }
       
       .markdown-editor-header {
         vertical-align: top;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -412,7 +412,7 @@ table.investment-projects-summary {
 .markdown-editor {
   background-color: white;
   
-  .mardown-area,
+  .markdown-area,
   #markdown-preview {
     display: none;
   }
@@ -660,7 +660,7 @@ table.investment-projects-summary {
   
   .fullscreen {
     
-    .mardown-area,
+    .markdown-area,
     #markdown-preview {
       display: block;
     }

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -75,7 +75,7 @@
           <span><%= t("admin.legislation.draft_versions.form.fullscreen_toggle")%></span> <span class="icon-expand"></span>
         <% end %>
       </div>
-      <div class="small-12 medium-6 column mardown-area">
+      <div class="small-12 medium-6 column markdown-area">
         <%= f.text_area :body, label: false, placeholder: t('admin.legislation.draft_versions.form.body_placeholder') %>
       </div>
       <div id="markdown-preview" class="small-12 medium-6 column">

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -63,20 +63,19 @@
       <%= f.label :body %>
       <small><%= t('admin.legislation.draft_versions.form.use_markdown') %></small>
     </div>
-    <br/>
     <div class="markdown-editor">
-      <div class="small-12 column fullscreen-container">
-            <div class="markdown-editor-header truncate">Consul | Editando <span class="strong">Versión 3</span> del proceso <span class="strong">Licencias urbanísticas, declaraciones</span></div>
+      <div class="small-12 medium-8 column fullscreen-container">
+        <div class="markdown-editor-header truncate">Consul | Editando <span class="strong">Versión 3</span> del proceso <span class="strong">Licencias urbanísticas, declaraciones</span></div>
 
-            <div class="markdown-editor-buttons">
-              <%= f.submit(class: "button", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
-            </div>
+        <div class="markdown-editor-buttons">
+          <%= f.submit(class: "button", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
+        </div>
 
         <%= link_to "#", class: 'fullscreen-toggle' do %>
           <span><%= t("admin.legislation.draft_versions.form.fullscreen_toggle")%></span> <span class="icon-expand"></span>
         <% end %>
       </div>
-      <div class="small-12 medium-6 column">
+      <div class="small-12 medium-6 column mardown-area">
         <%= f.text_area :body, label: false, placeholder: t('admin.legislation.draft_versions.form.body_placeholder') %>
       </div>
       <div id="markdown-preview" class="small-12 medium-6 column">

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -65,14 +65,17 @@
     </div>
     <div class="markdown-editor">
       <div class="small-12 medium-8 column fullscreen-container">
-        <div class="markdown-editor-header truncate">Consul | Editando <span class="strong">Versión 3</span> del proceso <span class="strong">Licencias urbanísticas, declaraciones</span></div>
+        <div class="markdown-editor-header truncate"><%= t('admin.legislation.draft_versions.form.title_html', draft_version_title: @draft_version.title, process_title: @process.title ) %></div>
 
         <div class="markdown-editor-buttons">
           <%= f.submit(class: "button", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
         </div>
 
         <%= link_to "#", class: 'fullscreen-toggle' do %>
-          <span><%= t("admin.legislation.draft_versions.form.fullscreen_toggle")%></span> <span class="icon-expand"></span>
+          <span data-closed-text="<%= t("admin.legislation.draft_versions.form.launch_text_editor")%>"
+                data-open-text="<%= t("admin.legislation.draft_versions.form.close_text_editor")%>">
+            <%= t("admin.legislation.draft_versions.form.launch_text_editor")%>
+          </span>
         <% end %>
       </div>
       <div class="small-12 medium-6 column markdown-area">

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -245,7 +245,9 @@ en:
           form:
             error: Error
         form:
-          fullscreen_toggle: Toggle full screen
+          title_html: 'Editing <span class="strong">%{draft_version_title}</span> from the process <span class="strong">%{process_title}</span>'
+          launch_text_editor: Launch text editor
+          close_text_editor: Close text editor
           use_markdown: Use Markdown to format the text
           hints:
             final_version: This version will be published as Final Result for this process. Comments won't be allowed in this version.

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -245,7 +245,9 @@ es:
           form:
             error: Error
         form:
-          fullscreen_toggle: Pantalla completa
+          title_html: 'Editando <span class="strong">%{draft_version_title}</span> del proceso <span class="strong">%{process_title}</span>'
+          launch_text_editor: Lanzar editor de texto
+          close_text_editor: Cerrar editor de texto
           use_markdown: Usa Markdown para formatear el texto
           hints:
             final_version: Será la versión que se publique en Publicación de Resultados. Esta versión no se podrá comentar

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -86,10 +86,14 @@ feature 'Admin legislation draft versions' do
 
       click_link 'Version 1'
 
+      click_link 'Launch text editor'
+
       fill_in 'legislation_draft_version_title', with: 'Version 1b'
       fill_in 'legislation_draft_version_body', with: '# Version 1 body\r\n\r\nParagraph\r\n\r\n>Quote'
 
-      click_button 'Save changes'
+      within('.fullscreen') do
+        click_button 'Save changes'
+      end
 
       expect(page).to have_content 'Version 1b'
     end


### PR DESCRIPTION
This PR fixes #92, hiding the legislation text when the full-screen mode is not active.

The legislation admin look is now closer to the Invision screens.