### PR TITLE
Invert share buttons layout

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -527,13 +527,6 @@ $epigraph-line-height: rem-calc(22);
 .draft-panels {
   position: relative;
   padding: 2rem 0;
-  
-  aside.absolute {
-    @include breakpoint(medium) {
-      position: absolute;
-      right: 0;
-    }
-  }
 
   .draft-chooser {
     margin-bottom: 2rem;
@@ -1118,6 +1111,10 @@ $epigraph-line-height: rem-calc(22);
 // 10. Legislation draft comment
 // -----------------
 .legislation-comment {
+  
+  .annotation-share-comment {
+    margin-bottom: 2rem;
+  }
 
   .pull-right {
     float: right;

--- a/app/views/legislation/annotations/_slim_version_chooser.html.erb
+++ b/app/views/legislation/annotations/_slim_version_chooser.html.erb
@@ -17,7 +17,7 @@
     <div class="sidebar-divider"></div>
     <h2>Compartir</h2>
     <div class="social-share-full">
-      <%= render '/legislation/shared/share_buttons', title: @draft_version.title %>
+      <%= render '/legislation/shared/share_buttons', title: t('legislation.shared.share_comment', version_name: @draft_version.title.downcase, process_name: @process.title) %>
     </div>
   </aside>
 </div>

--- a/app/views/legislation/annotations/index.html.erb
+++ b/app/views/legislation/annotations/index.html.erb
@@ -6,15 +6,7 @@
 
 <div class="column row">
   <div class="draft-panels small-12 column row">
-    <%= render 'version_chooser', process: @process, draft_version: @draft_version %>
-
-    <aside class="small-12 medium-3 column absolute">
-      <div class="sidebar-divider"></div>
-      <h2>Compartir</h2>
-      <div class="social-share-full">
-        <%= render '/legislation/shared/share_buttons', title: "#{@draft_version.title} - #{@process.title}" %>
-      </div>
-    </aside>
+    <%= render 'slim_version_chooser', process: @process, draft_version: @draft_version %>
   </div>
 
   <div class="small-12 medium-8 column row legislation-comments end">

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -29,14 +29,14 @@
               </div>
             </div>
           </div>
-          
+
           <aside class="small-12 medium-3 column">
             <div class="sidebar-divider"></div>
             <h2>Compartir</h2>
             <div class="social-share-full">
-              <%= render '/legislation/shared/share_buttons', title: @draft_version.title %>
+              <%= render '/legislation/shared/share_buttons', title: t('legislation.shared.share_comment', version_name: @draft_version.title.downcase, process_name: @process.title) %>
             </div>
-          </aside>    
+          </aside>
         </div>
 
       <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree, comment_flags: @comment_flags } %>

--- a/app/views/legislation/annotations/show.html.erb
+++ b/app/views/legislation/annotations/show.html.erb
@@ -6,31 +6,40 @@
 
 <div class="column row">
   <div class="draft-panels small-12 column row">
-    <%= render 'slim_version_chooser', process: @process, draft_version: @draft_version %>
+    <%= render 'version_chooser', process: @process, draft_version: @draft_version %>
 
-    <div class="row">
-      <div class="small-12 medium-12 column legislation-comment">
-        <div class="annotation-comment">
-          <strong><%= t('legislation.annotations.index.comments_about') %></strong>
-          <div class="comment-section">
-            <div class="row">
-              <div class="small-12 medium-10 column legislation-comment">
-                <%= @annotation.context.try(:html_safe).presence || @annotation.quote %>
-              </div>
-              <div class="small-12 medium-2 column legislation-comment">
-                <span class="pull-right">
-                  <%= link_to legislation_process_draft_version_path(@process, @draft_version, anchor: "annotation-id-#{@annotation.id}") do %>
-                    <span><%= t('legislation.annotations.index.see_in_context') %></span> <span class="icon-expand" aria-hidden="true"></span>
-                  <% end %>
-                </span>
+    <div class="legislation-comment">
+      <div class="annotation-comment">
+        <div class="row annotation-share-comment">
+          <div class="small-12 medium-9 column">
+            <strong><%= t('legislation.annotations.index.comments_about') %></strong>
+
+            <div class="comment-section">
+              <div class="row">
+                <div class="small-12 medium-9 column legislation-comment">
+                  <%= @annotation.context.try(:html_safe).presence || @annotation.quote %>
+                </div>
+                <div class="small-12 medium-3 column legislation-comment">
+                  <span class="pull-right">
+                    <%= link_to legislation_process_draft_version_path(@process, @draft_version, anchor: "annotation-id-#{@annotation.id}") do %>
+                      <span><%= t('legislation.annotations.index.see_in_context') %></span> <span class="icon-expand" aria-hidden="true"></span>
+                    <% end %>
+                  </span>
+                </div>
               </div>
             </div>
+          </div>
+          
+          <aside class="small-12 medium-3 column">
+            <div class="sidebar-divider"></div>
+            <h2>Compartir</h2>
+            <div class="social-share-full">
+              <%= render '/legislation/shared/share_buttons', title: @draft_version.title %>
+            </div>
+          </aside>    
         </div>
 
-        <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree, comment_flags: @comment_flags } %>
-
+      <%= render partial: '/comments/comment_tree', locals: { comment_tree: @comment_tree, comment_flags: @comment_flags } %>
       </div>
     </div>
-
   </div>
-</div>

--- a/config/locales/legislation.en.yml
+++ b/config/locales/legislation.en.yml
@@ -112,3 +112,4 @@ en:
       share_twitter: Share on Twitter
       share_facebook: Share on Facebook
       share_gplus: Share on Google+
+      share_comment: Comment on %{version_name} from process draft %{process_name}

--- a/config/locales/legislation.es.yml
+++ b/config/locales/legislation.es.yml
@@ -112,3 +112,4 @@ es:
       share_twitter: Compartir en Twitter
       share_facebook: Compartir en Facebook
       share_gplus: Compartir en Google+
+      share_comment: Comentario sobre la %{version_name} del borrador del proceso %{process_name}


### PR DESCRIPTION
Changes the position of each share button in the annotation comment pages, according to the latest review in #107.