### PR TITLE
Fix comment box login warning display

### DIFF
--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -14,4 +14,5 @@ App.Votes =
     App.Votes.hoverize "div.votes"
     App.Votes.hoverize "div.supports"
     App.Votes.hoverize "div.debate-questions"
+    App.Votes.hoverize "div.comment-footer"
     false

--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -870,6 +870,25 @@ $epigraph-line-height: rem-calc(22);
             float: right;
           }
         }
+        
+        .comments-wrapper {
+          position: relative;
+          
+          .participation-not-allowed {
+            padding: 1.25rem 0.5rem;
+          }
+        }
+        
+        .comment-footer {
+          position: relative;
+          
+          .participation-not-allowed {
+            font-size: 0.875rem;
+            height: 50px;
+            padding: .85rem 0.75rem;
+            top: -18px;
+          }
+        }
 
         .comment-input {
           padding-bottom: 4rem;

--- a/app/views/legislation/annotations/_comments_box.html.erb
+++ b/app/views/legislation/annotations/_comments_box.html.erb
@@ -61,11 +61,15 @@
           <% end %>
         </div>
       <% else %>
-        <div data-alert class="callout primary">
+      
+      <div>
+        <div class="participation-not-allowed" style="display: none;" aria-hidden="false">
           <%= t("legislation.annotations.form.login_to_comment",
               signin: link_to(t("legislation.annotations.form.signin"), new_user_session_path),
               signup: link_to(t("legislation.annotations.form.signup"), new_user_registration_path)).html_safe %>
         </div>
+      </div>
+
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
This PR is connected to #125. It fixes the height of the login warning when the user is not logged in and hides/hovers the warning in the comment box footer.