### PR TITLE
Addressed preview comments

### DIFF
--- a/app/assets/stylesheets/proposal.scss
+++ b/app/assets/stylesheets/proposal.scss
@@ -9,3 +9,10 @@
     align-items: center;
   }
 }
+
+.proposal-created {
+  margin-bottom: 1.5rem;
+  .row {
+    background-color: #e7f3fd;
+  }
+}

--- a/app/views/proposals/_preview.html.erb
+++ b/app/views/proposals/_preview.html.erb
@@ -123,66 +123,68 @@
         </div>
       </div>
 
-      <aside class="small-12 medium-3 column">
-        <% if can?(:dashboard, @proposal) %>
+      <% unless preview %>
+        <aside class="small-12 medium-3 column">
+          <% if can?(:dashboard, @proposal) %>
+            <div class="sidebar-divider"></div>
+            <h2><%= t("proposals.show.author") %></h2>
+            <div class="show-actions-menu">
+              <%= link_to proposal_dashboard_index_path(@proposal), class: 'button hollow expanded', id: "proposal-dashboard-#{@proposal.id}" do %>
+                          <span class="icon-edit"></span>
+                          <%= t("proposals.show.dashboard_proposal_link") %>
+              <% end %>
+            </div>
+          <% end %>
+
           <div class="sidebar-divider"></div>
-          <h2><%= t("proposals.show.author") %></h2>
-          <div class="show-actions-menu">
-            <%= link_to proposal_dashboard_index_path(@proposal), class: 'button hollow expanded', id: "proposal-dashboard-#{@proposal.id}" do %>
-                        <span class="icon-edit"></span>
-                        <%= t("proposals.show.dashboard_proposal_link") %>
+          <h2><%= t("votes.supports") %></h2>
+          <div id="<%= dom_id(@proposal) %>_votes">
+            <% if @proposal.draft? %>
+              <p><%= t '.draft' %></p>
+            <% elsif @proposal.successful? %>
+              <p>
+                <%= t("proposals.proposal.successful",
+                    voting: link_to(t("proposals.proposal.voting"), polls_path)).html_safe %>
+              </p>
+              <% if can? :create, Poll::Question %>
+                <p class="text-center">
+                  <%= link_to t('poll_questions.create_question'),
+                              new_admin_question_path(proposal_id: @proposal.id),
+                              class: "button hollow expanded" %>
+                </p>
+              <% end %>
+            <% elsif @proposal.archived? %>
+              <div class="padding text-center">
+                <p>
+                  <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
+                </p>
+                <p><%= t("proposals.proposal.archived") %></p>
+              </div>
+            <% else %>
+              <%= render 'votes',
+                        { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: 'yes') } %>
             <% end %>
           </div>
-        <% end %>
 
-        <div class="sidebar-divider"></div>
-        <h2><%= t("votes.supports") %></h2>
-        <div id="<%= dom_id(@proposal) %>_votes">
-          <% if @proposal.draft? %>
-            <p><%= t '.draft' %></p>
-          <% elsif @proposal.successful? %>
-            <p>
-              <%= t("proposals.proposal.successful",
-                  voting: link_to(t("proposals.proposal.voting"), polls_path)).html_safe %>
-            </p>
-            <% if can? :create, Poll::Question %>
-              <p class="text-center">
-                <%= link_to t('poll_questions.create_question'),
-                            new_admin_question_path(proposal_id: @proposal.id),
-                            class: "button hollow expanded" %>
-              </p>
-            <% end %>
-          <% elsif @proposal.archived? %>
-            <div class="padding text-center">
-              <p>
-                <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
-              </p>
-              <p><%= t("proposals.proposal.archived") %></p>
-            </div>
-          <% else %>
-            <%= render 'votes',
-                      { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: 'yes') } %>
+
+          <%= render partial: 'shared/social_share', locals: {
+            share_title: t("proposals.show.share"),
+            title: @proposal.title,
+            url: proposal_url(@proposal),
+            description: @proposal.summary
+          } %>
+
+          <% if current_user %>
+            <div class="sidebar-divider"></div>
+            <p class="sidebar-title"><%= t("shared.follow") %></p>
+
+            <%= render 'follows/follow_button', follow: find_or_build_follow(current_user, @proposal)  %>
           <% end %>
-        </div>
 
+          <%= render 'communities/access_button', community: @proposal.community %>
 
-        <%= render partial: 'shared/social_share', locals: {
-          share_title: t("proposals.show.share"),
-          title: @proposal.title,
-          url: proposal_url(@proposal),
-          description: @proposal.summary
-        } %>
-
-        <% if current_user %>
-          <div class="sidebar-divider"></div>
-          <p class="sidebar-title"><%= t("shared.follow") %></p>
-
-          <%= render 'follows/follow_button', follow: find_or_build_follow(current_user, @proposal)  %>
-        <% end %>
-
-        <%= render 'communities/access_button', community: @proposal.community %>
-
-      </aside>
+        </aside>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/proposals/created.html.erb
+++ b/app/views/proposals/created.html.erb
@@ -11,4 +11,10 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="small-12 column">
+    <h3><%= t('.preview_title') %></h3>
+  </div>
+</div>
+
 <%= render 'preview', preview: true %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -313,11 +313,13 @@ en:
         boost your proposal.
         </p>
         <p>
-        Do you think you need help to achieve this goal? If so, leave your proposal
-        as a draft and we will guide you.
+          <strong>Do you think you need help to achieve this goal?</strong>
+          <br>
+          If so, leave your proposal as a draft and we will guide you.
         </p>
       publish: No, I want to publish the proposal
       dashboard: Yes, I want help and I'll publish later
+      preview_title: This is how your proposal will look when you publish it
     share:
       improve_it: Improve your campaign and get more support.
       dashboard: See more information

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -313,11 +313,13 @@ es:
           impulsar tu propuesta.
         </p>
         <p>
-          ¿Crees que necesitas ayuda para alcanzar esta meta? Si es así, deja tu propuesta
-          como borrador y te guiaremos.
+          <strong>¿Crees que necesitas ayuda para alcanzar esta meta?</strong>
+          <br>
+          Si es así, deja tu propuesta como borrador y te guiaremos.
         </p>
       publish: No, quiero publicar la propuesta ya
       dashboard: Si, quiero ayuda y publicaré mas tarde
+      preview_title: Así es como quedará tu propuesta cuando la publiques
     share:
       improve_it: Mejora tu campaña y consigue mas apoyos.
       dashboard: Ver mas información


### PR DESCRIPTION
References
===================

Objectives
===================

Address preview comments made on Slack regarding the preview that is shown after the proposal creation



Visual Changes
===================
The action area (where the user can choose whether to publish it or being redirected to the dashboard) has changed its background color and now it is clearly differentiated

A subtitle indicating where the preview starts has been added.

The right column won't appear during the preview.
