### PR TITLE
Fixes #171

### DIFF
--- a/app/views/layouts/dashboard/_proposal_totals.html.erb
+++ b/app/views/layouts/dashboard/_proposal_totals.html.erb
@@ -40,7 +40,11 @@
       </div>
 
       <div class="proposal-link">
-        <%= link_to t('.show_proposal'), proposal_path(proposal), class: 'button success expanded' %>
+        <% if proposal.draft? %>
+          <%= link_to t('.preview_proposal'), proposal_path(proposal), class: 'button success expanded', target: '_blank' %>
+        <% else %>
+          <%= link_to t('.show_proposal'), proposal_path(proposal), class: 'button success expanded', target: '_blank' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -205,6 +205,7 @@ en:
         active_resources: Active resources
         community: Community
         show_proposal: Show proposal
+        preview_proposal: Preview proposal
         current_goal: Current goal
         support_count:
           one: "%{count} support" 

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -205,6 +205,7 @@ es:
         active_resources: Recursos activos
         community: Comunidad
         show_proposal: Ver propuesta
+        preview_proposal: Previsualizar propuesta
         current_goal: Meta actual
         support_count:
           one: "%{count} apoyo"


### PR DESCRIPTION
Button that redirects to proposal in the proposals dashboard now:

* opens the proposal in a different tab.
* Text shown will be 'preview proposal' for proposals in draft state.

References
===================
Implements #171 

Objectives
===================
Adjust the behaviour of the 'View proposal' button according to what was decided during the sprint meeting on June, the 28th.

Visual Changes
===================
![issue_171](https://user-images.githubusercontent.com/1701962/42073707-9071062a-7b68-11e8-918b-e252832dd90e.gif)

