### PR TITLE
Fixes #232

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -27,7 +27,11 @@ class Community < ActiveRecord::Base
   end
 
   def comments_count
-    Comment.where(commentable: topics).count
+    comments.count
+  end
+
+  def comments
+    Comment.where(commentable: topics)
   end
 
   def debates_count

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -39,6 +39,7 @@ class Poll < ActiveRecord::Base
   scope :overlaping_with, lambda { |poll| 
     where('? < ends_at and ? >= starts_at', poll.starts_at.beginning_of_day, poll.ends_at.end_of_day)
       .where.not(id: poll.id)
+      .where(related: poll.related)
   }
 
   scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }

--- a/app/views/dashboard/polls/_poll.html.erb
+++ b/app/views/dashboard/polls/_poll.html.erb
@@ -19,11 +19,9 @@
 
     <div class="card-section text-center">
       <% if poll.incoming? %>
-        <%= link_to 'Editar encuesta', edit_proposal_dashboard_poll_path(proposal, poll), class: 'button hollow' %>
+        <%= link_to t('.edit_poll'), edit_proposal_dashboard_poll_path(proposal, poll), class: 'button hollow' %>
       <% else %>
-        <a href='#' class="button">
-          <%= t('.view_responses') %>
-        </a>
+        <%= link_to t('.view_responses'), proposal_dashboard_poll_path(proposal, poll), class: 'button' %>
       <% end %>
     </div>
     <div class="card-section">

--- a/app/views/dashboard/polls/_poll_header.html.erb
+++ b/app/views/dashboard/polls/_poll_header.html.erb
@@ -1,7 +1,3 @@
-<%= link_to t("admin.polls.edit.title"),
-            edit_proposal_dashboard_poll_path(proposal, poll),
-            class: "button hollow float-right" %>
-
 <h2 class="inline-block">
   <%= poll.name %>
 </h2>

--- a/app/views/proposals_dashboard/_comment.html.erb
+++ b/app/views/proposals_dashboard/_comment.html.erb
@@ -1,0 +1,10 @@
+<li>
+  <%= comment.body %>
+  <p class="help-text">
+    <%= comment.commentable.title %>
+    -
+    <%= l(comment.updated_at.to_date) %>
+    -
+    <%= comment.author.name %>
+  </p>
+</li>

--- a/app/views/proposals_dashboard/_topic.html.erb
+++ b/app/views/proposals_dashboard/_topic.html.erb
@@ -1,8 +1,0 @@
-<li>
-  <strong><%= topic.title %></strong>
-  <p class="help-text">
-    <%= l(topic.updated_at.to_date) %>
-    -
-    <%= topic.author.name %>
-  </p>
-</li>

--- a/app/views/proposals_dashboard/community.html.erb
+++ b/app/views/proposals_dashboard/community.html.erb
@@ -27,13 +27,13 @@
   </div>
 </div>
 
-<% if proposal.community.topics.any? %>
+<% if proposal.community.comments.any? %>
   <div class="action-title">
-    <h5><%= t('.latest_topics') %></h5>
+    <h5><%= t('.latest_comments') %></h5>
     <hr>
   </div>
 
   <ul>
-    <%= render partial: 'topic', collection: proposal.community.topics %>
+    <%= render partial: 'comment', collection: proposal.community.comments.sort_by_newest.limit(5) %>
   </ul>
 <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -560,7 +560,7 @@ en:
       participants: Participants
       debates: Debates
       comments: Comments
-      latest_topics: Latest topics
+      latest_comments: Latest messages
   dashboard:
     polls:
       index:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -577,6 +577,7 @@ en:
           one: "%{count} response"
           other: "%{count} responses"
         view_responses: View responses
+        edit_poll: Edit survey
         show_results: Show results
         show_results_help: If you check this box the results will be public and all users will be able to see them
       form:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -577,6 +577,7 @@ es:
           one: "%{count} respuesta"
           other: "%{count} respuestas"
         view_responses: Ver respuestas
+        edit_poll: Editar encuesta
         show_results: Mostrar resultados
         show_results_help: Si marcas esta casilla los resultados serán públicos y todos los usuarios podrán verlos
       form:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -560,7 +560,7 @@ es:
       participants: Participantes
       debates: Debates
       comments: Comentarios
-      latest_topics: Últimos debates
+      latest_comments: Últimos mensajes
   dashboard:
     polls:
       index:


### PR DESCRIPTION
In proposal's dashboard, inside community section, the latests topics
has been replaced by latest messages.

References
===================
Fixes #232 

Objectives
===================
Latest topics must be replaced by latest messages inside  proposal dashboard, in community section.

Visual Changes
===================
![ultimos_mensajes](https://user-images.githubusercontent.com/1701962/42890504-4e4f46c2-8aad-11e8-8350-a3167845bfd4.png)
